### PR TITLE
New composer rules (Makefile)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,14 @@ composer-install: ## Install composer dependencies.
 composer-update: ## Update composer dependencies.
 	$(COMPOSER_UPDATE)
 .PHONY: composer-update
+
+composer-validate: ## Validate composer.json file.
+	$(COMPOSER) validate
+.PHONY: composer-validate
+
+composer-validate-deep: ## Validate composer.json and composer.lock files in strict mode.
+	$(COMPOSER) validate --strict --check-lock
+.PHONY: composer-validate-deep
 #---------------------------------------------#
 
 ## === 📦  NPM ===================================================


### PR DESCRIPTION
This PR adds 2 new composer rules:

* `composer-validate`: validates the `composer.json` file
* `composer-validate-deep`: same as above but also includes `composer.lock` in strict mode