### PR TITLE
Add new Makefile entry to audit code using Composer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,10 @@ qa-lint-container: ## Lint container.
 qa-lint-schema: ## Lint Doctrine schema.
 	$(SYMFONY_CONSOLE) doctrine:schema:validate --skip-sync -vvv --no-interaction
 .PHONY: qa-lint-schema
+
+qa-audit: ## Run composer audit.
+	$(COMPOSER) audit
+.PHONY: qa-audit
 #---------------------------------------------#
 
 ## === 🔎  TESTS =================================================


### PR DESCRIPTION
With Composer 2.4 there is a new command called `audit` that lists reported security vulnerabilities on current package versions.

More info here https://php.watch/articles/composer-audit

This PR adds a new entry to the Makefile to easily call this command.