### PR TITLE
Correctif : il manque un tiret à la commande docker-compose dans la variable DOCKER_COMPOSE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 #---DOCKER---#
 DOCKER = docker
 DOCKER_RUN = $(DOCKER) run
-DOCKER_COMPOSE = docker compose
+DOCKER_COMPOSE = docker-compose
 DOCKER_COMPOSE_UP = $(DOCKER_COMPOSE) up -d
 DOCKER_COMPOSE_STOP = $(DOCKER_COMPOSE) stop
 #------------#


### PR DESCRIPTION
Correctif : il manque un tiret à la commande docker-compose dans la variable DOCKER_COMPOSE