### PR TITLE
IMPROVE: use 'symfony composer' instead of 'composer' alone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ SYMFONY_LINT = $(SYMFONY_CONSOLE) lint:
 #------------#
 
 #---COMPOSER-#
-COMPOSER = composer
+COMPOSER = $(SYMFONY) composer
 COMPOSER_INSTALL = $(COMPOSER) install
 COMPOSER_UPDATE = $(COMPOSER) update
 #------------#

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -17,7 +17,7 @@ vars:
   SYMFONY_SERVER_STOP: "{{.SYMFONY}} server:stop"
   SYMFONY_CONSOLE: "{{.SYMFONY}} console"
   SYMFONY_LINT: "{{.SYMFONY_CONSOLE}} lint:"
-  COMPOSER: composer
+  COMPOSER: "{{.SYMFONY}} composer"
   COMPOSER_INSTALL: "{{.COMPOSER}} install"
   COMPOSER_UPDATE: "{{.COMPOSER}} update"
   NPM: npm


### PR DESCRIPTION
Utilisation de la commande 'symfony composer' au lieu de 'composer' seul pour, notamment, créer toutes les variables d'environnement passées à docker durant l'installation.