### PR TITLE
🐛 FIX: ${PWD} should be escaped

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ NPM_WATCH = $(NPM) run watch
 
 #---PHPQA---#
 PHPQA = jakzal/phpqa
-PHPQA_RUN = $(DOCKER_RUN) --init -it --rm -v $(PWD):/project -w /project $(PHPQA)
+PHPQA_RUN = $(DOCKER_RUN) --init -it --rm -v "$(PWD):/project" -w /project $(PHPQA)
 #------------#
 
 #---PHPUNIT-#


### PR DESCRIPTION
Bravo pour ton travail ! 
J'ai eu cependant un petit problème lors de l'utilisation du Makefile, puisque mon nom de dossier comporte des espaces (pas bien, je sais).

Pour remédier à celà, j'ai dû modifier la ligne suivante : 
`PHPQA_RUN = $(DOCKER_RUN) --init --rm -v $(PWD):/project -w /project $(PHPQA)` en `PHPQA_RUN = $(DOCKER_RUN) --init --rm -v "$(PWD):/project" -w /project $(PHPQA)`

Sinon tout est parfait, merci ! 